### PR TITLE
Fix github link of WebAssembly working group

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <nav>
         <h3>Getting involved</h3>
         <ul>
-          <li><a href="https://github.com/orgs/w3c/teams/web-assembly/repositories">Github</a></li>
+          <li><a href="https://github.com/w3c/wasm-wg/">Github</a></li>
           <li><a href="https://lists.w3.org/Archives/Public/public-webassembly/">Mailing list</a></li>
           <li><a href="https://www.w3.org/Consortium/cepc/">Code of Conduct</a></li>
           <li><a href="https://webassembly.org/">Community page</a></li>


### PR DESCRIPTION
Fixed broken link of Github.

`https://github.com/orgs/w3c/teams/web-assembly/repositories` gives 404 error.

#1 