### PR TITLE
update proposals url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # W3C WebAssembly Working Group
 
-* [proposals](https://github.com/WebAssembly/proposals/blob/master/README.md)
+* [proposals](https://github.com/WebAssembly/proposals/blob/main/README.md)
 * [Working Group homepage](https://www.w3.org/wasm/)
 
 ## Specifications


### PR DESCRIPTION
https://github.com/WebAssembly/proposals/ has renamed default branch master to main, this pr updates the link.